### PR TITLE
Top Bar Breakpoint Visibility

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -378,7 +378,7 @@
         if (!$dropdown.find('.title.back').length) {
 
           if (settings.mobile_show_parent_link == true && url) {
-            $titleLi = $('<li class="title back js-generated"><h5><a href="javascript:void(0)"></a></h5></li><li class="parent-link hide-for-medium-up"><a class="parent-link js-generated" href="' + url + '">' + $link.html() +'</a></li>');
+            $titleLi = $('<li class="title back js-generated"><h5><a href="javascript:void(0)"></a></h5></li><li class="parent-link hide-for-top-bar-desktop-up"><a class="parent-link js-generated" href="' + url + '">' + $link.html() +'</a></li>');
           } else {
             $titleLi = $('<li class="title back js-generated"><h5><a href="javascript:void(0)"></a></h5>');
           }

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -302,6 +302,9 @@ $medium-breakpoint: em-calc(1024) !default;
 $large-breakpoint:  em-calc(1440) !default;
 $xlarge-breakpoint: em-calc(1920) !default;
 
+// Using rem-calc for the below breakpoint causes issues with top bar
+$topbar-breakpoint: $small-breakpoint  + em-calc(1) !default; // Change to 9999px for always mobile layout
+
 $small-range:   (0, $small-breakpoint) !default;
 $medium-range:  ($small-breakpoint  + em-calc(1), $medium-breakpoint) !default;
 $large-range:   ($medium-breakpoint + em-calc(1), $large-breakpoint)  !default;
@@ -327,6 +330,8 @@ $xlarge-only: "#{$screen} and (min-width:#{lower-bound($xlarge-range)}) and (max
 
 $xxlarge-up: "#{$screen} and (min-width:#{lower-bound($xxlarge-range)})" !default;
 $xxlarge-only: "#{$screen} and (min-width:#{lower-bound($xxlarge-range)}) and (max-width:#{upper-bound($xxlarge-range)})" !default;
+
+$topbar-media-query: "#{$screen} and (min-width:#{lower-bound($topbar-breakpoint)})";
 
 $retina: (
   "#{$screen} and (-webkit-min-device-pixel-ratio: 2)",

--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -9,6 +9,7 @@
 //
 $include-html-grid-classes: $include-html-classes !default;
 $include-xl-html-grid-classes: false !default;
+$include-top-bar-html-grid-classes: false !default;
 
 $row-width: rem-calc(1000) !default;
 $total-columns: 12 !default;
@@ -280,7 +281,14 @@ $last-child-float: $opposite-direction !default;
         }
       }
     }
+  }  
+  
+  @if $include-top-bar-html-grid-classes {
+    @media #{$topbar-media-query} {
+      @include grid-html-classes($size:top-bar-desktop);
+    }
   }
+  
   @if $include-xl-html-grid-classes {
     @media #{$xlarge-up} {
       @include grid-html-classes($size:xlarge);

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -74,9 +74,6 @@ $topbar-menu-icon-position: $opposite-direction !default; // Change to $default-
 
 // Transitions and breakpoint styles
 $topbar-transition-speed: 300ms !default;
-// Using rem-calc for the below breakpoint causes issues with top bar
-$topbar-breakpoint: #{lower-bound($medium-range)} !default; // Change to 9999px for always mobile layout
-$topbar-media-query: "#{$screen} and (min-width:#{lower-bound($topbar-breakpoint)})";
 
 // Top-bar input styles
 $topbar-input-height: rem-calc(28) !default;

--- a/scss/foundation/components/_visibility.scss
+++ b/scss/foundation/components/_visibility.scss
@@ -21,14 +21,16 @@ $visibility-breakpoint-sizes:
   medium,
   large,
   xlarge,
-  xxlarge;
+  xxlarge,
+  top-bar-desktop;
 
 $visibility-breakpoint-queries:
   unquote($small-up),
   unquote($medium-up),
   unquote($large-up),
   unquote($xlarge-up),
-  unquote($xxlarge-up);
+  unquote($xxlarge-up),
+  unquote($topbar-media-query);
 
 @mixin visibility-loop {
   @each $current-visibility-breakpoint in $visibility-breakpoint-sizes {


### PR DESCRIPTION
Discussed in #6248

Add visibility classes based on top-bar's breakpoint.

Make top-bar show and hide parent-links based on these new visibility
classes instead of medium.

Add grid classes based on top-bar breakpoint. (Optional  - off by
default)
